### PR TITLE
Return remaining text from Unmarshal().

### DIFF
--- a/decode.go
+++ b/decode.go
@@ -7,14 +7,14 @@ import (
 	"strings"
 )
 
-func Unmarshal(data string, v interface{}) error {
+func Unmarshal(data string, v interface{}) (string, error) {
 	val := reflect.ValueOf(v)
 	val = reflect.Indirect(val)
 	if !val.CanSet() {
-		return errors.New("tnetstring: Unmarshal requires a settable value")
+		return data, errors.New("tnetstring: Unmarshal requires a settable value")
 	}
-	_, err := unmarshal(data, val)
-	return err
+	n, err := unmarshal(data, val)
+	return data[n:], err
 }
 
 func indirect(v reflect.Value) reflect.Value {

--- a/tnetstring_test.go
+++ b/tnetstring_test.go
@@ -76,9 +76,12 @@ func TestUnmarshal(t *testing.T) {
 			continue
 		}
 		val := reflect.New(ty)
-		err := Unmarshal(test.data, val.Interface())
+		rest, err := Unmarshal(test.data, val.Interface())
 		if err != nil {
 			t.Errorf("#%d Unmarshal error: %s", i, err)
+		}
+		if rest != "" {
+			t.Errorf("#%d Unmarshal returned non-empty left-over: %v", i, rest)
 		}
 		if !reflect.DeepEqual(test.val, val.Elem().Interface()) {
 			t.Errorf("#%d want\n%v\ngot\n%v", i, test.val, val.Elem().Interface())


### PR DESCRIPTION
When a TNetstring is followed by other data (e.g. other TNetstrings) it's useful to know what that other data is.  An additional method could be added, but the current minimal Marshal/Unmarshal is nice and clean. This is a minimal change to make that trailing data easily available.

I found this necessary when parsing Mongrel2 messages.  Unfortuantely, it is a backwards-incompatible change.
