### PR TITLE
decode-nested-array-values

### DIFF
--- a/decode.go
+++ b/decode.go
@@ -21,16 +21,19 @@ func indirect(v reflect.Value) reflect.Value {
 	for {
 		switch v.Kind() {
 		case reflect.Ptr:
+			print("Ptr")
 			if v.IsNil() {
 				v.Set(reflect.New(v.Type().Elem()))
 			}
 			v = v.Elem()
 		case reflect.Interface:
+			print("Interface")
 			if v.IsNil() {
 				return v
 			}
 			v = v.Elem()
 		default:
+			print("Default")
 			return v
 		}
 	}

--- a/decode.go
+++ b/decode.go
@@ -21,19 +21,16 @@ func indirect(v reflect.Value) reflect.Value {
 	for {
 		switch v.Kind() {
 		case reflect.Ptr:
-			print("Ptr")
 			if v.IsNil() {
 				v.Set(reflect.New(v.Type().Elem()))
 			}
 			v = v.Elem()
 		case reflect.Interface:
-			print("Interface")
 			if v.IsNil() {
 				return v
 			}
 			v = v.Elem()
 		default:
-			print("Default")
 			return v
 		}
 	}

--- a/tnetstring_test.go
+++ b/tnetstring_test.go
@@ -52,6 +52,7 @@ var tnetstringTests = []tnetstringTest{
 		A int
 		B string
 	}{1, "hello"}, "20:1:A,1:1#1:B,5:hello,}"},
+	{map[string]interface{}{"a": [][2]string{[2]string{"b", "c"}}, "d": "e"}, "27:1:d,1:e,1:a,11:8:1:b,1:c,]]}"},
 }
 
 var tests = append(stableTests, tnetstringTests...)


### PR DESCRIPTION
I'm trying to use `tnetstring-go` to encode/decode a structure like:

``` javascript
{
  "id":        "string-uuid",
  "method":    "get",
  "uri":       "http://example.com",
  "headers":   [["name1", "value1"], ["name2", "value2"]],
  "body":      "body-string",
  "user-data": {"more": "keys",
                "and":  "values"}
}
```

I'm still groking the code to figure out what the issue is, but in the
meantime I have a failing test case.
